### PR TITLE
Use createRoot / createElement for Next.js compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { render, h } from 'preact';
+import { createRoot } from 'preact/compat/client';
+import { createElement } from 'preact';
 
 import Importer from './importer';
 export * from './types';
@@ -13,7 +14,7 @@ export function renderImporter(
   element: HTMLElement,
   props: ImporterDefinition
 ) {
-  render(h(Importer, props), element);
+  createRoot(element).render(createElement(Importer, props));
 }
 
 export { OuterStateBuilder as CsvImporterStateBuilder };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig(({ mode }): UserConfig => {
       alias: isReact
         ? {
             ...baseAlias,
+            'preact/compat/client': 'react-dom/client',
             'preact/compat': resolve(__dirname, 'shims/react-compat-shim.js'),
             'preact/jsx-runtime': 'react/jsx-runtime',
             'preact/hooks': 'react',
@@ -59,7 +60,7 @@ export default defineConfig(({ mode }): UserConfig => {
         external: isBundled
           ? []
           : isReact
-            ? ['react', 'react-dom', 'react/jsx-runtime']
+            ? ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client']
             : ['preact'],
         output: {
           globals: isBundled


### PR DESCRIPTION
This aims to fix issue #261,

I tried building all the examples (example-next-js / example-preact / example-react (with react 18 and 19) and example-vanilla) to make sure everything works, and there seems to be no issue.

Thanks again for the great library ;)